### PR TITLE
Use tfsec, sops.

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Run Terrascan on Terraform configuration
-        run: docker-compose run terrascan
+      - name: Run tfsec on Terraform configuration
+        run: docker-compose run tfsec
 
   plan:
     name: Plan deployment

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ We recommend integrating the following with your editor:
 
 - [Prettier](https://prettier.io/) to apply consistent code formatting rules. These rules are enforced on commit, so editor integration significantly reduces frustration.
 
+## Managing secrets
+
+Secrets needed beyond AWS credentials are encrypted in this repository using [sops](https://github.com/mozilla/sops). To edit the encrypted files in `terraform/vault`, specify the file to edit like this:
+
+```bash
+docker-compose run --entrypoint sops terraform vault/internal.enc.yml
+```
+
+Your AWS credentials must be accessible in the environment, and they must be able to access the encryption key in AWS KMS.
+
 ## Other documentation
 
 | File                                     | Contents                                                                                              |

--- a/TODO
+++ b/TODO
@@ -2,4 +2,4 @@
 - Add caching (using Cloudfront?) of outbound HTTP requests
 - Support for temporary API keys for demoing?
 - Linting
-- Fix terrascan results
+- Fix tfsec results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,13 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: '${AWS_ACCESS_KEY_ID}'
       AWS_SECRET_ACCESS_KEY: '${AWS_SECRET_ACCESS_KEY}'
+      SOPS_KMS_ARN: arn:aws:kms:us-east-1:885514992300:key/f8193811-a18f-4d06-9389-2c9af5c27f7d
 
-  terrascan:
-    image: accurics/terrascan
+  tfsec:
+    image: liamg/tfsec
     volumes:
       - ./terraform:/terraform
-    command: scan -d /terraform
+    entrypoint: tfsec /terraform
 
   tflint:
     image: wata727/tflint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:prettier:fix": "prettier -w .",
     "lint:tflint": "docker-compose run tflint",
     "test": "docker-compose run api test",
-    "scan": "docker-compose run terrascan"
+    "scan": "docker-compose run tfsec"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,4 +1,6 @@
-FROM hashicorp/terraform:0.12.26
-WORKDIR /terraform
+FROM hashicorp/terraform:0.13.5
+RUN wget https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux -O /bin/sops
+RUN chmod +x /bin/sops
 
+WORKDIR /terraform
 CMD ["terraform"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,9 +5,19 @@ terraform {
     region = "us-east-1"
     dynamodb_table = "terraform"
   }
+
+  required_providers {
+    aws = {
+      source = "aws"
+      version = "3.14.1"
+    }
+  }
 }
 
 provider "aws" {
-  version = "~> 3.0"
   region = "us-east-1"
+}
+
+module "vault" {
+  source = "./vault"
 }

--- a/terraform/ui.tf
+++ b/terraform/ui.tf
@@ -1,25 +1,37 @@
+# Logging is not needed for the web host bucket. (AWS002)
+# Encryption is not needed for these public files. (AWS017)
+# tfsec:ignore:AWS002 tfsec:ignore:AWS017
 resource "aws_s3_bucket" "ui" {
   bucket = "unfurl.page"
-  acl = "public-read"
+  acl = "private"
 
   website {
     index_document = "index.html"
     error_document = "404.html"
   }
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_policy" "ui" {
   bucket = aws_s3_bucket.ui.id
-  policy = data.aws_iam_policy_document.allow_public_read.json
+  policy = data.aws_iam_policy_document.allow_cloudfront_read.json
 }
 
-data "aws_iam_policy_document" "allow_public_read" {
+data "aws_iam_policy_document" "allow_cloudfront_read" {
   statement {
-    actions = ["s3:GetObject"]
+    actions = ["s3:GetObject","s3:GetObjectVersion"]
     resources = ["${aws_s3_bucket.ui.arn}/*"]
     principals {
       type = "*"
       identifiers = ["*"]
+    }
+    condition {
+      test = "StringLike"
+      variable = "aws:Referer"
+      values = [module.vault.ui_bucket_shared_secret]
     }
   }
 }

--- a/terraform/vault/internal.enc.yml
+++ b/terraform/vault/internal.enc.yml
@@ -1,0 +1,15 @@
+ui_bucket_shared_secret: ENC[AES256_GCM,data:2Q9vZIItuFNSHSa/V2/4MfQqYRiM9vsEIoEiXKVM0C188BpNy4GtLVQxq4A=,iv:En76A4DhAIoHvBjWTYxXgWT6xC+DDNgCDfA8uZ75rxc=,tag:SrbHlUeC62mE6pzcO0xeWg==,type:str]
+sops:
+  kms:
+    - arn: arn:aws:kms:us-east-1:885514992300:key/f8193811-a18f-4d06-9389-2c9af5c27f7d
+      created_at: '2020-11-12T04:37:35Z'
+      enc: AQICAHizRBYMo3Bcgz49l0iMd+74y6vJBpikku4vUDiv5PrQEQEnu4fswDVTt3AZs80+rQa/AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMei0/p3XvxWz3kKm3AgEQgDsAe2fvSHVMo92hKqpVNV7mbMF2Q4kUdKAa1frr7IhE6fSeCX/wNxp9vQ5bHB52KtUDL78VbOPlXJ9r8A==
+      aws_profile: ''
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  lastmodified: '2020-11-12T04:46:47Z'
+  mac: ENC[AES256_GCM,data:56xtRneYB8x/3FJV48LKbxluhox1zCU3fTGcs++prv4S3+al5568EtLrQvTPI1GqDBaNFlaRzVEKBe5Cj+qnbZOnxEMGEuOFamF2Aorpzko8cKFWWf1KAj41gyb7jtyVLgji4pV3PkQm7RbYgpVmn8Drc3UpUcGhRGR5q+qdDrE=,iv:DtBy+yn6/V3OidZ23Z4nFBpiKOCkbI2V39Ud8onK4ss=,tag:kZKbhiOKEqtmfPyyvFFEGw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.6.1

--- a/terraform/vault/main.tf
+++ b/terraform/vault/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    sops = {
+      source = "carlpett/sops"
+      version = "0.5.2"
+    }
+  }
+}
+
+provider "sops" {}
+
+data "sops_file" "internal" {
+  source_file = "vault/internal.enc.yml"
+}

--- a/terraform/vault/outputs.tf
+++ b/terraform/vault/outputs.tf
@@ -1,0 +1,4 @@
+output "ui_bucket_shared_secret" {
+  value = data.sops_file.internal.data["ui_bucket_shared_secret"]
+  sensitive = true
+}


### PR DESCRIPTION
terrascan didn’t behave as nicely as expected; it doesn’t allow accepting risk (ignoring rulesets). `tfsec` seems much more flushed out.

Still showing secrets in plan outputs, but that’s for another day as the stored secret isn’t very… secret. Fixes known issues as reported by tfsec.