### PR TITLE
Allow lambda to access DynamoDB.

### DIFF
--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -22,6 +22,6 @@ describe('GET /', () => {
       'https://www.unfurl.page/documentation',
     );
 
-    expect(payload).toHaveProperty('page_url', 'http://example.com/page');
+    expect(payload).toHaveProperty('page_url', 'http://example.com/pages');
   });
 });

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -49,6 +49,19 @@ data "aws_iam_policy_document" "api_lambda_assume_role_policy" {
   }
 }
 
+resource "aws_iam_role_policy" "api_lambda" {
+  name = "api_lambda"
+  role = aws_iam_role.api_lambda.id
+  policy = data.aws_iam_policy_document.api_lambda_allow_dynamodb_access.json
+}
+
+data "aws_iam_policy_document" "api_lambda_allow_dynamodb_access" {
+  statement {
+    actions = ["dynamodb:*"]
+    resources = [module.db.api_keys_arn]
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "api_lambda_logs" {
   role = aws_iam_role.api_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"

--- a/terraform/db/outputs.tf
+++ b/terraform/db/outputs.tf
@@ -1,0 +1,3 @@
+output "api_keys_arn" {
+  value = aws_dynamodb_table.api_keys.arn
+}


### PR DESCRIPTION
Following up to #5, needed to grant access to access DynamoDB from the Lambda role.