### PR TITLE
Pass all arguments to terraform.

### DIFF
--- a/terraform/bin/entrypoint.sh
+++ b/terraform/bin/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-sops exec-env variables.enc.yml "terraform $@"
+sops exec-env variables.enc.yml "terraform $*"


### PR DESCRIPTION
Followup from #11, this fixes passing arguments through sops to terraform. 

- `$@` is all arguments, quoted. This resulted in `sh` executing (not desired): 

  ```sh
  sops exec-env variables.enc.yml 'terraform apply' --auto-approve`
  ```
- `$*` is all arguments as a single string, without parsing. This results in `sh` executing (desired): 

  ```sh
  sops exec-env variables.enc.yml 'terraform apply --auto-approve'
  ```